### PR TITLE
TERA-291: Add aws ci cd Dockerfile

### DIFF
--- a/src/aws-ci-cd/Dockerfile
+++ b/src/aws-ci-cd/Dockerfile
@@ -1,0 +1,20 @@
+##
+ # Node-Alpine based image with AWS CLI and some standard tools for CI-CD
+ # _____________________________________________________________________________
+ #
+ # Created by brightSPARK Labs
+ # www.brightsparklabs.com
+ ##
+
+FROM node:14.7.0-alpine
+
+# install utility packages
+RUN apk add --no-cache python
+RUN apk add --no-cache py-pip
+RUN apk add --no-cache bash
+RUN apk add --no-cache jq
+RUN apk add --no-cache openssh
+RUN apk add --no-cache git
+RUN pip install awscli
+
+ENTRYPOINT ["/bin/bash"]

--- a/src/aws-ci-cd/Dockerfile
+++ b/src/aws-ci-cd/Dockerfile
@@ -7,6 +7,8 @@
  ##
 
 FROM node:14.7.0-alpine
+MAINTAINER brightSPARK Labs <enquire@brightsparklabs.com>
+LABEL Description="Node-Alpine based image with AWS CLI and some standard tools for CI-CD" Vendor="brightSPARK Labs"
 
 # install utility packages
 RUN apk add --no-cache python


### PR DESCRIPTION
Adding basic Dockerfile to help with CI CD.
Image has:
- AWS cli
- bash
- jq
- openssh
- git